### PR TITLE
Add getPin() function and the ability to force analogWrite.

### DIFF
--- a/src/ezLED.cpp
+++ b/src/ezLED.cpp
@@ -38,6 +38,7 @@ ezLED::ezLED(int pin, int mode) {
 	_ledState    = LED_STATE_IDLE;
 	_outputState = LED_OFF; // LED_OFF, LED_ON
 	_brightness  = 0;  // 0 to 255
+	_forceAnalog = false;
 
 	_fadeFrom           = 0;
 	_fadeTo             = 0;
@@ -52,6 +53,10 @@ ezLED::ezLED(int pin, int mode) {
 	_blinkCounter       = 0;
 
 	pinMode(_ledPin, OUTPUT);
+}
+
+void ezLED::useAnalog(bool forceAnalog) {
+	_forceAnalog = forceAnalog;
 }
 
 void ezLED::setBlink(unsigned long onTime, unsigned long offTime, unsigned long delayTime) {
@@ -75,7 +80,12 @@ void ezLED::updateDigital() {
 	else
 		state = (_outputState == LED_OFF) ? HIGH : LOW;
 
-	digitalWrite(_ledPin, state);
+	if (_forceAnalog == true) {
+		_brightness = state == HIGH ? 255 : 0;
+		updateAnalog();
+	} else {
+		digitalWrite(_ledPin, state);
+	}
 }
 
 void ezLED::turnON(unsigned long delayTime) {
@@ -218,6 +228,10 @@ int ezLED::getState(void) {
 		default:
 			return LED_IDLE;
 	}
+}
+
+int ezLED::getPin(void) {
+	return _ledPin;
 }
 
 void ezLED::loop(void) {

--- a/src/ezLED.h
+++ b/src/ezLED.h
@@ -68,6 +68,7 @@ class ezLED
 		unsigned char _ledState;
 		unsigned char _outputState; // LED_OFF, LED_ON
 		int _brightness;  // 0 to 255
+		bool _forceAnalog = false;
 
 		unsigned char _fadeFrom = 0;
 		unsigned char _fadeTo = 0;
@@ -87,6 +88,7 @@ class ezLED
 
 	public:
 		ezLED(int pin, int mode = CTRL_ANODE);
+		void useAnalog(bool forceAnalog);
 		void turnON(unsigned long delayTime = 0);
 		void turnOFF(unsigned long delayTime = 0);
 		void toggle(unsigned long delayTime = 0);
@@ -101,6 +103,7 @@ class ezLED
 
 		int getOnOff(void);
 		int getState(void);
+		int getPin(void);
 		void loop(void);
 };
 


### PR DESCRIPTION
Add function
int getPin(void)
Useful when using LED array to get pin.

Add function
void useAnalog(bool forceAnalog)
This will force analogWrite instead of digitalWrite to apply LED state. Useful to get rid of bug like this one https://github.com/ARMmbed/mbed-os/pull/14488#issuecomment-953553198